### PR TITLE
docs: CLAUDE.md をポインタ構造に整理する

### DIFF
--- a/.claude/rules/domain-changes.md
+++ b/.claude/rules/domain-changes.md
@@ -1,0 +1,9 @@
+---
+description: domain 層を変更するときのルール
+paths:
+  - "src/domain/**"
+  - "tests/domain/**"
+---
+
+- domain 層を変更するときはテストを先に更新する
+- 復習ルールを変更するときは docs/adr/0003-review-rule.md を更新する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,21 @@
 # CLAUDE.md
 
+## プロジェクト概要
+漢字読み学習アプリ（Expo/React Native）
+
 ## 真実の場所
 - 問題型定義：src/domain/problem.ts
-- 正誤判定：src/domain/answer.ts（テスト：tests/domain/answer.test.ts）
-- 復習ルール：src/domain/review.ts（テスト：tests/domain/review.test.ts）
+- 正誤判定：src/domain/answer.ts
+- 復習ルール：src/domain/review.ts
 - 問題データ：data/problems/
-
-## 作業前に実行すること
-※ RN init 完了後（フェーズ1以降）に有効になる
-- `npm run typecheck`
-- `npm run test`
-- `npm run lint`
-
-## 変更時のルール
-- domain 層を変更するときはテストを先に更新する
-- 復習ルールを変更するときは docs/adr/0003-review-rule.md を更新する
 
 ## ドキュメント
 - PRD：docs/prd/001-kanji-learning-app.md
 - ADR：docs/adr/
+- レビュールール：.claude/rules/
+
+## 作業前コマンド
+※ RN init 完了後（フェーズ1以降）に有効
+```
+npm run typecheck && npm run test && npm run lint
+```


### PR DESCRIPTION
closes #12

## Summary
- 説明文・ルール記述を削除し、ファイルパスポインタのみに絞る
- domain 変更ルールを `.claude/rules/domain-changes.md` に移動（`paths` frontmatter で domain/tests ファイル編集時に動的注入）
- 21行に削減（DoD: 50行以内）

## 参考
https://zenn.dev/cureapp/articles/65b9a99d22ce2b — CLAUDE.md はポインタのみ、ルールは `.claude/rules/` に分離する方針

## Test plan
- [x] CLAUDE.md が 50 行以内
- [x] 説明文ではなくポインタ（パス・コマンド）だけが残っている
- [x] domain-changes.md に paths 指定あり（動的注入対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)