### PR TITLE
harness: new-issue・PR 作成時に自身を自動 assign する

### DIFF
--- a/.claude/skills/new-issue/SKILL.md
+++ b/.claude/skills/new-issue/SKILL.md
@@ -40,6 +40,7 @@ gh issue create \
   --title "タイトル" \
   --label "ラベル" \
   --milestone "マイルストーン名" \
+  --assignee "@me" \
   --body $'## 背景\n\n内容\n\n## やること\n\n- [ ] 項目\n\n## 完了条件（DoD）\n\n- [ ] 項目\n\n## スコープ外\n\n- 項目'
 ```
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -89,6 +89,7 @@ Closes #XX
 gh pr create \
   --repo reiya0104/kanji-learning \
   --title "<prefix>: <変更内容>" \
+  --assignee "@me" \
   --body "$(cat <<'EOF'
 （ステップ4で生成した description を、ここに直接貼り付ける）
 EOF


### PR DESCRIPTION
## 変更内容

- /new-issue スキルの gh issue create に `--assignee "@me"` を追加
- /review-pr スキルの gh pr create に `--assignee "@me"` を追加

## 対応 Issue

Closes #28

## 影響範囲

- .claude/skills/new-issue/SKILL.md
- .claude/skills/review-pr/SKILL.md

## 確認項目
- [ ] lint 通過
- [ ] typecheck 通過
- [ ] test 通過