### PR TITLE
feat: 画面ナビゲーション設定（#3）

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,10 @@
-import { StatusBar } from 'expo-status-bar'
-import { StyleSheet, Text, View } from 'react-native'
+import { NavigationContainer } from '@react-navigation/native'
+import RootNavigator from './src/navigation/RootNavigator'
 
 export default function App() {
   return (
-    <View testID="root-screen" style={styles.container}>
-      <Text>漢字学習アプリ</Text>
-      <StatusBar style="auto" />
-    </View>
+    <NavigationContainer>
+      <RootNavigator />
+    </NavigationContainer>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-})

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,17 @@
       "name": "kanji-learning",
       "version": "1.0.0",
       "dependencies": {
+        "@react-navigation/native": "^7.2.0",
+        "@react-navigation/native-stack": "^7.14.7",
         "expo": "~52.0.0",
         "expo-asset": "~11.0.5",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
-        "react-native": "0.76.9"
+        "react-native": "0.76.9",
+        "react-native-safe-area-context": "~5.1.0",
+        "react-native-screens": "~4.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
@@ -4338,6 +4342,169 @@
         }
       }
     },
+    "node_modules/@react-navigation/core": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.0.tgz",
+      "integrity": "sha512-E4Kr1PRrhKiVn1RdMdPIG1rCfrKh+HiVJ2smdLsh9D95Q2z0a9dGE9yHpRQ2pAUiiwOfgloLqegkPb8g+TcCBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/routers": "^7.5.3",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "query-string": "^7.1.3",
+        "react-is": "^19.1.0",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-navigation/elements": {
+      "version": "2.9.12",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.12.tgz",
+      "integrity": "sha512-LSaQUj5SV9OXVRcxT8mqETDoM7BOKCveCvuLjdAr9NZnPDM5HW8uDnvW/sCa8oEFy+22+ojoXtHFKsfnesgBbw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@react-native-masked-view/masked-view": ">= 0.2.0",
+        "@react-navigation/native": "^7.2.0",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-masked-view/masked-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-navigation/elements/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@react-navigation/elements/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.0.tgz",
+      "integrity": "sha512-kEuqIS1MkzzLD45Fp17CrxAchoB4W6tMfc541merUgtAeNNsg06gRrvmuLv6LAYvpLifGdXuSjpluPIu/VmbQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.17.0",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.7.tgz",
+      "integrity": "sha512-MxKdKS817YK7iirlyW+XZnXJ339eRE7aA3E55zHVDS+R+bqro+PwRwNGqL1Y9e3w0KjAKZVsOfn5erJRWrO4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.12",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.2.0",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@react-navigation/native-stack/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@react-navigation/native-stack/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.5.3.tgz",
+      "integrity": "sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -7529,6 +7696,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -9761,7 +9937,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9906,6 +10081,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -15276,6 +15460,24 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -15388,6 +15590,18 @@
         }
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -15453,6 +15667,30 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.1.0.tgz",
+      "integrity": "sha512-Y4vyJX+0HPJUQNVeIJTj2/UOjbSJcB09OEwirAWDrOZ67Lz5p43AmjxSy8nnZft1rMzoh3rcPuonB6jJyHTfCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.1.0.tgz",
+      "integrity": "sha512-tCBwe7fRMpoi/nIgZxE86N8b2SH8d5PlfGaQO8lgqlXqIyvwqm3u1HJCaA0tsacPyzhW7vVtRfQyq9e1j0S2gA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
@@ -16326,6 +16564,15 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sf-symbols-typescript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz",
+      "integrity": "sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -16485,6 +16732,21 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -16536,6 +16798,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/sprintf-js": {
@@ -16702,6 +16973,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -17987,6 +18267,24 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -18079,6 +18377,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,17 @@
     "build:e2e": "detox build -c android.emu.debug"
   },
   "dependencies": {
+    "@react-navigation/native": "^7.2.0",
+    "@react-navigation/native-stack": "^7.14.7",
     "expo": "~52.0.0",
     "expo-asset": "~11.0.5",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.9"
+    "react-native": "0.76.9",
+    "react-native-safe-area-context": "~5.1.0",
+    "react-native-screens": "~4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,0 +1,17 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import type { RootStackParamList } from './types'
+import HomeScreen from '../screens/HomeScreen'
+import SessionScreen from '../screens/SessionScreen'
+import ResultScreen from '../screens/ResultScreen'
+
+const Stack = createNativeStackNavigator<RootStackParamList>()
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator initialRouteName="Home">
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Session" component={SessionScreen} />
+      <Stack.Screen name="Result" component={ResultScreen} />
+    </Stack.Navigator>
+  )
+}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,14 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+
+export type RootStackParamList = {
+  Home: undefined
+  Session: undefined
+  Result: {
+    correctCount: number
+    missedProblemIds: string[]
+  }
+}
+
+export type HomeScreenProps = NativeStackScreenProps<RootStackParamList, 'Home'>
+export type SessionScreenProps = NativeStackScreenProps<RootStackParamList, 'Session'>
+export type ResultScreenProps = NativeStackScreenProps<RootStackParamList, 'Result'>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,24 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import type { HomeScreenProps } from '../navigation/types'
+
+export default function HomeScreen({ navigation }: HomeScreenProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>漢字学習アプリ</Text>
+      <TouchableOpacity
+        testID="start-session-button"
+        style={styles.button}
+        onPress={() => navigation.navigate('Session')}
+      >
+        <Text style={styles.buttonText}>セッション開始</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 32 },
+  button: { backgroundColor: '#4A90E2', borderRadius: 8, padding: 16 },
+  buttonText: { color: '#fff', fontSize: 18 },
+})

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,0 +1,16 @@
+import { View, Text, StyleSheet } from 'react-native'
+import type { ResultScreenProps } from '../navigation/types'
+
+export default function ResultScreen({ route }: ResultScreenProps) {
+  const { correctCount, missedProblemIds } = route.params
+  return (
+    <View style={styles.container}>
+      <Text testID="correct-count">正解数: {correctCount}</Text>
+      <Text testID="missed-count">間違えた問題数: {missedProblemIds.length}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+})

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -1,0 +1,22 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import type { SessionScreenProps } from '../navigation/types'
+
+export default function SessionScreen({ navigation }: SessionScreenProps) {
+  return (
+    <View style={styles.container}>
+      <Text>セッション画面（実装予定）</Text>
+      <TouchableOpacity
+        testID="go-to-result-button"
+        onPress={() =>
+          navigation.navigate('Result', { correctCount: 0, missedProblemIds: [] })
+        }
+      >
+        <Text>結果へ（仮）</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+})

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -2,8 +2,13 @@ import { render, screen } from '@testing-library/react-native'
 import App from '../App'
 
 describe('App', () => {
-  it('アプリ名テキストが表示される', () => {
+  it('ホーム画面のタイトルが表示される', () => {
     render(<App />)
     expect(screen.getByText('漢字学習アプリ')).toBeDefined()
+  })
+
+  it('セッション開始ボタンが表示される', () => {
+    render(<App />)
+    expect(screen.getByTestId('start-session-button')).toBeDefined()
   })
 })

--- a/tests/screens/HomeScreen.test.tsx
+++ b/tests/screens/HomeScreen.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import HomeScreen from '../../src/screens/HomeScreen'
+
+const mockNavigate = jest.fn()
+const mockNavigation = { navigate: mockNavigate } as any
+const mockRoute = {} as any
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('HomeScreen', () => {
+  describe('表示', () => {
+    it('アプリタイトルが表示される', () => {
+      render(<HomeScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('漢字学習アプリ')).toBeDefined()
+    })
+
+    it('セッション開始ボタンが表示される', () => {
+      render(<HomeScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByTestId('start-session-button')).toBeDefined()
+    })
+  })
+
+  describe('ナビゲーション', () => {
+    it('セッション開始ボタンをタップすると Session 画面へ遷移する', () => {
+      render(<HomeScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByTestId('start-session-button'))
+      expect(mockNavigate).toHaveBeenCalledWith('Session')
+    })
+  })
+})

--- a/tests/screens/ResultScreen.test.tsx
+++ b/tests/screens/ResultScreen.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react-native'
+import ResultScreen from '../../src/screens/ResultScreen'
+
+const mockNavigation = {} as any
+
+describe('ResultScreen', () => {
+  describe('表示', () => {
+    it('正解数が表示される', () => {
+      const mockRoute = {
+        params: { correctCount: 7, missedProblemIds: ['p-001', 'p-003', 'p-005'] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('正解数: 7')).toBeDefined()
+    })
+
+    it('間違えた問題数が表示される', () => {
+      const mockRoute = {
+        params: { correctCount: 7, missedProblemIds: ['p-001', 'p-003', 'p-005'] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('間違えた問題数: 3')).toBeDefined()
+    })
+
+    it('正解数 0 のときも正しく表示される', () => {
+      const mockRoute = {
+        params: { correctCount: 0, missedProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('正解数: 0')).toBeDefined()
+      expect(screen.getByText('間違えた問題数: 0')).toBeDefined()
+    })
+  })
+})

--- a/tests/screens/SessionScreen.test.tsx
+++ b/tests/screens/SessionScreen.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react-native'
+import SessionScreen from '../../src/screens/SessionScreen'
+
+const mockNavigate = jest.fn()
+const mockNavigation = { navigate: mockNavigate } as any
+const mockRoute = {} as any
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('SessionScreen', () => {
+  describe('表示', () => {
+    it('セッション画面のプレースホルダーテキストが表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('セッション画面（実装予定）')).toBeDefined()
+    })
+
+    it('結果画面へ進むボタンが表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByTestId('go-to-result-button')).toBeDefined()
+    })
+  })
+
+  describe('ナビゲーション', () => {
+    it('結果ボタンをタップすると correctCount と missedProblemIds を渡して Result 画面へ遷移する', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByTestId('go-to-result-button'))
+      expect(mockNavigate).toHaveBeenCalledWith('Result', {
+        correctCount: 0,
+        missedProblemIds: [],
+      })
+    })
+  })
+})


### PR DESCRIPTION
## 概要

フェーズ1の残タスク。React Navigation を導入し、ホーム → セッション → 結果の3画面スタックを構築する。

Closes #3

## 変更内容

- **パッケージ追加**: `@react-navigation/native`, `@react-navigation/native-stack`, `react-native-screens`, `react-native-safe-area-context`
- **`src/navigation/types.ts`**: `RootStackParamList` と各画面 Props 型エイリアスを定義（型安全なナビゲーション）
- **`src/navigation/RootNavigator.tsx`**: `createNativeStackNavigator<RootStackParamList>()` によるスタック定義
- **`src/screens/HomeScreen.tsx`**: タイトル表示 + セッション開始ボタン
- **`src/screens/SessionScreen.tsx`**: プレースホルダー（フェーズ2で実装）
- **`src/screens/ResultScreen.tsx`**: `correctCount` / `missedProblemIds` を表示（issue #7 との型整合性確保）
- **`App.tsx`**: `NavigationContainer + RootNavigator` に切り替え

## テスト

- 新規テスト9件追加（全23件パス）
- `HomeScreen`, `SessionScreen`, `ResultScreen` それぞれ単体テスト（navigation prop モック）
- `App.test.tsx` を HomeScreen 表示確認に更新

## 検証

```
npm run typecheck  ✅
npm test           ✅ 23/23 passed
npm run lint       ✅
```

https://claude.ai/code/session_018cDKCNqJZgV3Wj4MfbmXRV