### PR TITLE
harness: lint スクリプトに tests/**/*.tsx を追加する（#49）

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ios": "expo start --ios",
     "test": "jest",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint 'App.tsx' 'src/**/*.{ts,tsx}' 'tests/**/*.ts'",
+    "lint": "eslint 'App.tsx' 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'",
     "test:e2e": "detox test -c android.emu.debug",
     "test:e2e:ios": "detox test -c ios.sim.debug",
     "build:e2e": "detox build -c android.emu.debug"


### PR DESCRIPTION
## 変更内容

- lint スクリプトの対象を `tests/**/*.ts` から `tests/**/*.{ts,tsx}` に拡張

## 対応 Issue

Closes #49

## 影響範囲

- `package.json` の lint スクリプトのみ

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過