### PR TITLE
harness: 不要になった expo-status-bar を削除する（#50）

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "expo-asset": "~11.0.5",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
-    "expo-status-bar": "~2.0.0",
-    "react": "18.3.1",
+"react": "18.3.1",
     "react-native": "0.76.9",
     "react-native-safe-area-context": "~5.1.0",
     "react-native-screens": "~4.1.0"


### PR DESCRIPTION
## 変更内容

- `package.json` から `expo-status-bar` を削除（PR #48 で利用箇所がなくなったため）

## 対応 Issue

Closes #50

## 影響範囲

- `package.json` のみ

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過