### PR TITLE
feat: 問題データ読み込みとセッション用ランダム抽出（#4）

### DIFF
--- a/src/infrastructure/problemRepository.ts
+++ b/src/infrastructure/problemRepository.ts
@@ -1,0 +1,8 @@
+import type { Problem } from '../domain/problem'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const data = require('../../data/problems/sample.json') as Problem[]
+
+export function getAllProblems(): Problem[] {
+  return data
+}

--- a/src/usecase/sampleSession.ts
+++ b/src/usecase/sampleSession.ts
@@ -1,0 +1,10 @@
+import type { Problem } from '../domain/problem'
+
+export function pickSession(problems: Problem[], count: number): Problem[] {
+  const shuffled = [...problems]
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled.slice(0, count)
+}

--- a/tests/infrastructure/problemRepository.test.ts
+++ b/tests/infrastructure/problemRepository.test.ts
@@ -1,0 +1,28 @@
+import { getAllProblems } from '../../src/infrastructure/problemRepository'
+
+describe('getAllProblems', () => {
+  it('Problem[] を返す', () => {
+    const problems = getAllProblems()
+    expect(Array.isArray(problems)).toBe(true)
+    expect(problems.length).toBeGreaterThan(0)
+  })
+
+  it('各要素が Problem 型の必須フィールドを持つ', () => {
+    const problems = getAllProblems()
+    for (const p of problems) {
+      expect(typeof p.id).toBe('string')
+      expect(typeof p.question).toBe('string')
+      expect(typeof p.correct).toBe('string')
+      expect(Array.isArray(p.choices)).toBe(true)
+      expect(typeof p.level).toBe('number')
+      expect(Array.isArray(p.tags)).toBe(true)
+    }
+  })
+
+  it('choices に correct が含まれる', () => {
+    const problems = getAllProblems()
+    for (const p of problems) {
+      expect(p.choices).toContain(p.correct)
+    }
+  })
+})

--- a/tests/usecase/sampleSession.test.ts
+++ b/tests/usecase/sampleSession.test.ts
@@ -1,0 +1,49 @@
+import { pickSession } from '../../src/usecase/sampleSession'
+import type { Problem } from '../../src/domain/problem'
+
+const makeProblems = (n: number): Problem[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `p${i + 1}`,
+    question: `問${i + 1}`,
+    correct: 'こたえ',
+    choices: ['こたえ', 'ちがう1', 'ちがう2', 'ちがう3'],
+    level: 1,
+    tags: [],
+  }))
+
+describe('pickSession', () => {
+  it('count 件を返す', () => {
+    const problems = makeProblems(20)
+    expect(pickSession(problems, 10)).toHaveLength(10)
+  })
+
+  it('問題数が count 未満のときは全問返す', () => {
+    const problems = makeProblems(5)
+    expect(pickSession(problems, 10)).toHaveLength(5)
+  })
+
+  it('返却された問題は元のリストに含まれる', () => {
+    const problems = makeProblems(20)
+    const session = pickSession(problems, 10)
+    const ids = new Set(problems.map((p) => p.id))
+    for (const p of session) {
+      expect(ids.has(p.id)).toBe(true)
+    }
+  })
+
+  it('重複がない', () => {
+    const problems = makeProblems(20)
+    const session = pickSession(problems, 10)
+    const ids = session.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('毎回異なる順序を返す（10回中1回以上異なる）', () => {
+    const problems = makeProblems(20)
+    const results = Array.from({ length: 10 }, () =>
+      pickSession(problems, 10).map((p) => p.id).join(',')
+    )
+    const unique = new Set(results)
+    expect(unique.size).toBeGreaterThan(1)
+  })
+})


### PR DESCRIPTION
## 変更内容

- `src/infrastructure/problemRepository.ts`: `data/problems/sample.json` を読み込み `Problem[]` を返す `getAllProblems()` を実装
- `src/usecase/sampleSession.ts`: Fisher-Yates シャッフルで N 問をランダム抽出する `pickSession()` を実装

## 対応 Issue

Closes #4

## 影響範囲

- `src/infrastructure/` （新規）
- `src/usecase/` （新規）

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過（9 suites / 31 tests）