### PR TITLE
feat: 10問セッション管理を実装する（#5）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "expo-asset": "~11.0.5",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
-        "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
         "react-native": "0.76.9",
         "react-native-safe-area-context": "~5.1.0",
@@ -9915,16 +9914,6 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
-      }
-    },
-    "node_modules/expo-status-bar": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.0.1.tgz",
-      "integrity": "sha512-AkIPX7jWHRPp83UBZ1iXtVvyr0g+DgBVvIXTtlmPtmUsm8Vq9Bb5IGj86PW8osuFlgoTVAg7HI/+Ok7yEYwiRg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -1,22 +1,50 @@
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { useState } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { isCorrect } from '../domain/answer'
+import type { Problem } from '../domain/problem'
+import { getAllProblems } from '../infrastructure/problemRepository'
 import type { SessionScreenProps } from '../navigation/types'
+import { pickSession } from '../usecase/sampleSession'
+import ProblemScreen from './ProblemScreen'
+
+const SESSION_SIZE = 10
 
 export default function SessionScreen({ navigation }: SessionScreenProps) {
+  const [problems] = useState<Problem[]>(() => pickSession(getAllProblems(), SESSION_SIZE))
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [correctCount, setCorrectCount] = useState(0)
+  const [missedProblemIds, setMissedProblemIds] = useState<string[]>([])
+
+  const currentProblem = problems[currentIndex]
+
+  function handleAnswer(choice: string) {
+    const correct = isCorrect(currentProblem, choice)
+    const newCorrectCount = correct ? correctCount + 1 : correctCount
+    const newMissedIds = correct ? missedProblemIds : [...missedProblemIds, currentProblem.id]
+
+    if (currentIndex + 1 >= problems.length) {
+      navigation.navigate('Result', {
+        correctCount: newCorrectCount,
+        missedProblemIds: newMissedIds,
+      })
+    } else {
+      setCurrentIndex(currentIndex + 1)
+      setCorrectCount(newCorrectCount)
+      setMissedProblemIds(newMissedIds)
+    }
+  }
+
   return (
     <View style={styles.container}>
-      <Text>セッション画面（実装予定）</Text>
-      <TouchableOpacity
-        testID="go-to-result-button"
-        onPress={() =>
-          navigation.navigate('Result', { correctCount: 0, missedProblemIds: [] })
-        }
-      >
-        <Text>結果へ（仮）</Text>
-      </TouchableOpacity>
+      <Text testID="progress-text" style={styles.progress}>
+        {currentIndex + 1} / {problems.length}
+      </Text>
+      <ProblemScreen problem={currentProblem} onAnswer={handleAnswer} />
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  container: { flex: 1 },
+  progress: { textAlign: 'center', padding: 16, fontSize: 16 },
 })

--- a/tests/screens/SessionScreen.test.tsx
+++ b/tests/screens/SessionScreen.test.tsx
@@ -1,35 +1,95 @@
 import { render, screen, fireEvent } from '@testing-library/react-native'
 import SessionScreen from '../../src/screens/SessionScreen'
+import { getAllProblems } from '../../src/infrastructure/problemRepository'
+import { pickSession } from '../../src/usecase/sampleSession'
+import type { Problem } from '../../src/domain/problem'
+
+jest.mock('../../src/infrastructure/problemRepository')
+jest.mock('../../src/usecase/sampleSession')
+
+const mockGetAllProblems = getAllProblems as jest.Mock
+const mockPickSession = pickSession as jest.Mock
 
 const mockNavigate = jest.fn()
 const mockNavigation = { navigate: mockNavigate } as any
 const mockRoute = {} as any
 
+function makeProblems(count: number): Problem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `p${String(i + 1).padStart(3, '0')}`,
+    question: `漢字${i + 1}`,
+    correct: `よみ${i + 1}`,
+    choices: [`よみ${i + 1}`, `ちがう${i + 1}a`, `ちがう${i + 1}b`, `ちがう${i + 1}c`],
+    level: 1,
+    tags: [],
+  }))
+}
+
+const tenProblems = makeProblems(10)
+
 beforeEach(() => {
   jest.clearAllMocks()
+  mockGetAllProblems.mockReturnValue(tenProblems)
+  mockPickSession.mockReturnValue(tenProblems)
 })
 
 describe('SessionScreen', () => {
-  describe('表示', () => {
-    it('セッション画面のプレースホルダーテキストが表示される', () => {
+  describe('問題表示', () => {
+    it('1問目の漢字が画面に表示される', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
-      expect(screen.getByText('セッション画面（実装予定）')).toBeDefined()
+      expect(screen.getByText('漢字1')).toBeDefined()
     })
 
-    it('結果画面へ進むボタンが表示される', () => {
+    it('問題番号 "1 / 10" が表示される', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
-      expect(screen.getByTestId('go-to-result-button')).toBeDefined()
+      expect(screen.getByTestId('progress-text')).toBeDefined()
+      expect(screen.getByText('1 / 10')).toBeDefined()
     })
   })
 
-  describe('ナビゲーション', () => {
-    it('結果ボタンをタップすると correctCount と missedProblemIds を渡して Result 画面へ遷移する', () => {
+  describe('回答処理', () => {
+    it('回答すると次の問題（2問目）に進む', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
-      fireEvent.press(screen.getByTestId('go-to-result-button'))
-      expect(mockNavigate).toHaveBeenCalledWith('Result', {
-        correctCount: 0,
-        missedProblemIds: [],
-      })
+      fireEvent.press(screen.getByText('よみ1'))
+      expect(screen.getByText('漢字2')).toBeDefined()
+      expect(screen.getByText('2 / 10')).toBeDefined()
+    })
+
+    it('10問目に回答すると Result 画面へ遷移する', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      for (let i = 1; i <= 10; i++) {
+        fireEvent.press(screen.getByText(`よみ${i}`))
+      }
+      expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
+        correctCount: expect.any(Number),
+        missedProblemIds: expect.any(Array),
+      }))
+    })
+
+    it('正解数が正しく集計されて Result に渡される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      // 1問目: 正解、2問目: 不正解、3〜10問目: 正解
+      fireEvent.press(screen.getByText('よみ1'))       // 正解
+      fireEvent.press(screen.getByText('ちがう2a'))    // 不正解
+      for (let i = 3; i <= 10; i++) {
+        fireEvent.press(screen.getByText(`よみ${i}`))  // 正解
+      }
+      expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
+        correctCount: 9,
+      }))
+    })
+
+    it('不正解の問題 ID が missedProblemIds に含まれる', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      // 1問目: 正解、2問目: 不正解、3〜10問目: 正解
+      fireEvent.press(screen.getByText('よみ1'))
+      fireEvent.press(screen.getByText('ちがう2a'))
+      for (let i = 3; i <= 10; i++) {
+        fireEvent.press(screen.getByText(`よみ${i}`))
+      }
+      expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
+        missedProblemIds: ['p002'],
+      }))
     })
   })
 })


### PR DESCRIPTION
## 変更内容

- `SessionScreen` にセッション管理ロジックを実装
  - `pickSession(getAllProblems(), 10)` で10問を初期化
  - `useState` で現在インデックス・正解数・ミスIDを管理
  - `isCorrect()` で正誤判定し、10問終了後に Result 画面へ遷移
  - 進捗テキスト（`1 / 10` 形式）を表示
- `SessionScreen.test.tsx` をスケルトンテストから仕様テストに全面書き換え（6ケース）
- `package-lock.json` を `npm install` で再生成（`expo-status-bar` 削除の #50 のロックファイル反映）

## 対応 Issue

Closes #5

## 影響範囲

- `src/screens/SessionScreen.tsx`：スケルトンから完全実装へ
- `tests/screens/SessionScreen.test.tsx`：仕様テストに置き換え

## 確認項目

- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過（カバレッジ 100%）