### PR TITLE
harness: クラウド環境用 SessionStart フックを追加する

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SessionStart Hook: クラウド環境起動時の初期セットアップ
+# クラウド環境（CLAUDE_CODE_REMOTE=true）でのみ実行する
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "=== セッション開始: 依存パッケージをインストール中 ==="
+npm install
+echo "=== セットアップ完了 ==="

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "statusMessage": "依存パッケージをインストール中..."
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

- `.claude/hooks/session-start.sh` を新規作成：クラウドセッション起動時に `npm install` を自動実行
- `.claude/settings.json` に `SessionStart` フックを追加
- `CLAUDE_CODE_REMOTE=true` のときのみ実行し、ローカル開発には影響なし

## Test plan

- [x] `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` が正常完了することを確認
- [x] `eslint src/domain/answer.ts` — エラーなし
- [x] `jest tests/domain/answer.test.ts` — 3件すべて通過

https://claude.ai/code/session_01M28qvNCnyzkRGe6Rke311Y