### PR TITLE
chore: require を import に置き換えて resolveJsonModule を有効化する（#54）

### DIFF
--- a/src/infrastructure/problemRepository.ts
+++ b/src/infrastructure/problemRepository.ts
@@ -1,7 +1,5 @@
 import type { Problem } from '../domain/problem'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const data = require('../../data/problems/sample.json') as Problem[]
+import data from '../../data/problems/sample.json'
 
 export function getAllProblems(): Problem[] {
   return data

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist", "e2e"]


### PR DESCRIPTION
## 変更内容

- `tsconfig.json` に `resolveJsonModule: true` を追加
- `problemRepository.ts` の `require()` + `eslint-disable` コメントを `import` 構文に置き換え

## 対応 Issue

Closes #54

## 影響範囲

- `problemRepository.ts` のシグネチャ変更なし。呼び出し元 (`SessionScreen.tsx` 等) への影響なし
- `tsconfig.json` の変更はプロジェクト全体に適用されるが、JSON import を他で使っていないため副作用なし

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過