### PR TITLE
feat: 正誤判定フィードバック表示を実装 (#6)

### DIFF
--- a/src/screens/ProblemScreen.tsx
+++ b/src/screens/ProblemScreen.tsx
@@ -1,12 +1,19 @@
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import type { Problem } from '../domain/problem'
 
+export type Feedback = {
+  isCorrect: boolean
+  correctAnswer: string
+} | null
+
 type Props = {
   problem: Problem
   onAnswer: (choice: string) => void
+  feedback: Feedback
+  onNext: () => void
 }
 
-export default function ProblemScreen({ problem, onAnswer }: Props) {
+export default function ProblemScreen({ problem, onAnswer, feedback, onNext }: Props) {
   return (
     <View style={styles.container}>
       <Text style={styles.question}>{problem.question}</Text>
@@ -16,11 +23,37 @@ export default function ProblemScreen({ problem, onAnswer }: Props) {
             key={index}
             style={styles.choiceButton}
             onPress={() => onAnswer(choice)}
+            disabled={feedback !== null}
           >
             <Text style={styles.choiceText}>{choice}</Text>
           </TouchableOpacity>
         ))}
       </View>
+      {feedback !== null && (
+        <View
+          style={[
+            styles.feedbackContainer,
+            feedback.isCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect,
+          ]}
+        >
+          <Text
+            style={[
+              styles.feedbackText,
+              feedback.isCorrect ? styles.feedbackTextCorrect : styles.feedbackTextIncorrect,
+            ]}
+          >
+            {feedback.isCorrect ? '正解！' : '不正解'}
+          </Text>
+          {!feedback.isCorrect && (
+            <Text style={styles.correctAnswerText}>正解：{feedback.correctAnswer}</Text>
+          )}
+        </View>
+      )}
+      {feedback !== null && (
+        <TouchableOpacity testID="next-button" style={styles.nextButton} onPress={onNext}>
+          <Text style={styles.nextButtonText}>次へ</Text>
+        </TouchableOpacity>
+      )}
     </View>
   )
 }
@@ -49,5 +82,46 @@ const styles = StyleSheet.create({
   },
   choiceText: {
     fontSize: 20,
+  },
+  feedbackContainer: {
+    width: '100%',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  feedbackCorrect: {
+    backgroundColor: '#d4edda',
+  },
+  feedbackIncorrect: {
+    backgroundColor: '#f8d7da',
+  },
+  feedbackText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  feedbackTextCorrect: {
+    color: '#155724',
+  },
+  feedbackTextIncorrect: {
+    color: '#721c24',
+  },
+  correctAnswerText: {
+    fontSize: 16,
+    color: '#721c24',
+    marginTop: 8,
+  },
+  nextButton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 12,
+    width: '100%',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
   },
 })

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -5,7 +5,7 @@ import type { Problem } from '../domain/problem'
 import { getAllProblems } from '../infrastructure/problemRepository'
 import type { SessionScreenProps } from '../navigation/types'
 import { pickSession } from '../usecase/sampleSession'
-import ProblemScreen from './ProblemScreen'
+import ProblemScreen, { type Feedback } from './ProblemScreen'
 
 const SESSION_SIZE = 10
 
@@ -14,23 +14,29 @@ export default function SessionScreen({ navigation }: SessionScreenProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [correctCount, setCorrectCount] = useState(0)
   const [missedProblemIds, setMissedProblemIds] = useState<string[]>([])
+  const [feedback, setFeedback] = useState<Feedback>(null)
 
   const currentProblem = problems[currentIndex]
 
   function handleAnswer(choice: string) {
     const correct = isCorrect(currentProblem, choice)
-    const newCorrectCount = correct ? correctCount + 1 : correctCount
-    const newMissedIds = correct ? missedProblemIds : [...missedProblemIds, currentProblem.id]
+    if (correct) {
+      setCorrectCount((c) => c + 1)
+    } else {
+      setMissedProblemIds((ids) => [...ids, currentProblem.id])
+    }
+    setFeedback({ isCorrect: correct, correctAnswer: currentProblem.correct })
+  }
 
+  function handleNext() {
     if (currentIndex + 1 >= problems.length) {
       navigation.navigate('Result', {
-        correctCount: newCorrectCount,
-        missedProblemIds: newMissedIds,
+        correctCount,
+        missedProblemIds,
       })
     } else {
       setCurrentIndex(currentIndex + 1)
-      setCorrectCount(newCorrectCount)
-      setMissedProblemIds(newMissedIds)
+      setFeedback(null)
     }
   }
 
@@ -39,7 +45,12 @@ export default function SessionScreen({ navigation }: SessionScreenProps) {
       <Text testID="progress-text" style={styles.progress}>
         {currentIndex + 1} / {problems.length}
       </Text>
-      <ProblemScreen problem={currentProblem} onAnswer={handleAnswer} />
+      <ProblemScreen
+        problem={currentProblem}
+        onAnswer={handleAnswer}
+        feedback={feedback}
+        onNext={handleNext}
+      />
     </View>
   )
 }

--- a/tests/screens/ProblemScreen.test.tsx
+++ b/tests/screens/ProblemScreen.test.tsx
@@ -14,14 +14,14 @@ const mockProblem: Problem = {
 describe('ProblemScreen', () => {
   describe('問題表示', () => {
     it('問題の漢字（question）が表示される', () => {
-      render(<ProblemScreen problem={mockProblem} onAnswer={() => {}} />)
+      render(<ProblemScreen problem={mockProblem} onAnswer={() => {}} feedback={null} onNext={() => {}} />)
       expect(screen.getByText('漢字')).toBeDefined()
     })
   })
 
   describe('選択肢ボタン', () => {
     it('4つの選択肢ボタンが表示される', () => {
-      render(<ProblemScreen problem={mockProblem} onAnswer={() => {}} />)
+      render(<ProblemScreen problem={mockProblem} onAnswer={() => {}} feedback={null} onNext={() => {}} />)
       expect(screen.getByText('かんじ')).toBeDefined()
       expect(screen.getByText('かんご')).toBeDefined()
       expect(screen.getByText('えいご')).toBeDefined()
@@ -30,16 +30,111 @@ describe('ProblemScreen', () => {
 
     it('選択肢をタップすると onAnswer が選んだ選択肢を引数に呼ばれる', () => {
       const onAnswer = jest.fn()
-      render(<ProblemScreen problem={mockProblem} onAnswer={onAnswer} />)
+      render(<ProblemScreen problem={mockProblem} onAnswer={onAnswer} feedback={null} onNext={() => {}} />)
       fireEvent.press(screen.getByText('えいご'))
       expect(onAnswer).toHaveBeenCalledWith('えいご')
     })
 
     it('別の選択肢をタップしても onAnswer がその選択肢を引数に呼ばれる', () => {
       const onAnswer = jest.fn()
-      render(<ProblemScreen problem={mockProblem} onAnswer={onAnswer} />)
+      render(<ProblemScreen problem={mockProblem} onAnswer={onAnswer} feedback={null} onNext={() => {}} />)
       fireEvent.press(screen.getByText('かんじ'))
       expect(onAnswer).toHaveBeenCalledWith('かんじ')
+    })
+  })
+
+  describe('フィードバック表示', () => {
+    it('feedback が null のとき「次へ」ボタンは表示されない', () => {
+      render(<ProblemScreen problem={mockProblem} onAnswer={() => {}} feedback={null} onNext={() => {}} />)
+      expect(screen.queryByText('次へ')).toBeNull()
+    })
+
+    it('feedback.isCorrect が true のとき「正解！」テキストが表示される', () => {
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: true, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      expect(screen.getByText('正解！')).toBeDefined()
+    })
+
+    it('feedback.isCorrect が false のとき「不正解」テキストが表示される', () => {
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: false, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      expect(screen.getByText('不正解')).toBeDefined()
+    })
+
+    it('feedback.isCorrect が false のとき feedback.correctAnswer が表示される', () => {
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: false, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      expect(screen.getByText('正解：かんじ')).toBeDefined()
+    })
+
+    it('feedback.isCorrect が true のとき正解の読み仮名は表示されない', () => {
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: true, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      expect(screen.queryByText('正解：かんじ')).toBeNull()
+    })
+
+    it('feedback が非null のとき「次へ」ボタンが表示される', () => {
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: true, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      expect(screen.getByText('次へ')).toBeDefined()
+    })
+
+    it('「次へ」ボタンをタップすると onNext が呼ばれる', () => {
+      const onNext = jest.fn()
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={() => {}}
+          feedback={{ isCorrect: true, correctAnswer: 'かんじ' }}
+          onNext={onNext}
+        />
+      )
+      fireEvent.press(screen.getByText('次へ'))
+      expect(onNext).toHaveBeenCalledTimes(1)
+    })
+
+    it('feedback が非null のとき選択肢をタップしても onAnswer は呼ばれない', () => {
+      const onAnswer = jest.fn()
+      render(
+        <ProblemScreen
+          problem={mockProblem}
+          onAnswer={onAnswer}
+          feedback={{ isCorrect: true, correctAnswer: 'かんじ' }}
+          onNext={() => {}}
+        />
+      )
+      fireEvent.press(screen.getByText('えいご'))
+      expect(onAnswer).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/screens/SessionScreen.test.tsx
+++ b/tests/screens/SessionScreen.test.tsx
@@ -48,17 +48,19 @@ describe('SessionScreen', () => {
   })
 
   describe('回答処理', () => {
-    it('回答すると次の問題（2問目）に進む', () => {
+    it('回答して「次へ」を押すと次の問題（2問目）に進む', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
       fireEvent.press(screen.getByText('よみ1'))
+      fireEvent.press(screen.getByText('次へ'))
       expect(screen.getByText('漢字2')).toBeDefined()
       expect(screen.getByText('2 / 10')).toBeDefined()
     })
 
-    it('10問目に回答すると Result 画面へ遷移する', () => {
+    it('10問目に回答して「次へ」を押すと Result 画面へ遷移する', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
       for (let i = 1; i <= 10; i++) {
         fireEvent.press(screen.getByText(`よみ${i}`))
+        fireEvent.press(screen.getByText('次へ'))
       }
       expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
         correctCount: expect.any(Number),
@@ -70,9 +72,12 @@ describe('SessionScreen', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
       // 1問目: 正解、2問目: 不正解、3〜10問目: 正解
       fireEvent.press(screen.getByText('よみ1'))       // 正解
+      fireEvent.press(screen.getByText('次へ'))
       fireEvent.press(screen.getByText('ちがう2a'))    // 不正解
+      fireEvent.press(screen.getByText('次へ'))
       for (let i = 3; i <= 10; i++) {
         fireEvent.press(screen.getByText(`よみ${i}`))  // 正解
+        fireEvent.press(screen.getByText('次へ'))
       }
       expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
         correctCount: 9,
@@ -83,13 +88,62 @@ describe('SessionScreen', () => {
       render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
       // 1問目: 正解、2問目: 不正解、3〜10問目: 正解
       fireEvent.press(screen.getByText('よみ1'))
+      fireEvent.press(screen.getByText('次へ'))
       fireEvent.press(screen.getByText('ちがう2a'))
+      fireEvent.press(screen.getByText('次へ'))
       for (let i = 3; i <= 10; i++) {
         fireEvent.press(screen.getByText(`よみ${i}`))
+        fireEvent.press(screen.getByText('次へ'))
       }
       expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
         missedProblemIds: ['p002'],
       }))
+    })
+  })
+
+  describe('フィードバック表示（2フェーズフロー）', () => {
+    it('正解を選ぶと「正解！」が表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('よみ1'))
+      expect(screen.getByText('正解！')).toBeDefined()
+    })
+
+    it('不正解を選ぶと「不正解」が表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('ちがう1a'))
+      expect(screen.getByText('不正解')).toBeDefined()
+    })
+
+    it('不正解を選ぶと正解の読み仮名が表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('ちがう1a'))
+      expect(screen.getByText('正解：よみ1')).toBeDefined()
+    })
+
+    it('回答後は「次へ」ボタンが表示される', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('よみ1'))
+      expect(screen.getByText('次へ')).toBeDefined()
+    })
+
+    it('回答前は「次へ」ボタンが表示されない', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.queryByText('次へ')).toBeNull()
+    })
+
+    it('「次へ」を押すまで次の問題に進まない', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('よみ1'))
+      expect(screen.queryByText('漢字2')).toBeNull()
+      expect(screen.getByText('漢字1')).toBeDefined()
+    })
+
+    it('次の問題ではフィードバック表示がリセットされる', () => {
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('よみ1'))
+      expect(screen.getByText('正解！')).toBeDefined()
+      fireEvent.press(screen.getByText('次へ'))
+      expect(screen.queryByText('正解！')).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## 変更内容

- `ProblemScreen` に `feedback`・`onNext` props を追加し、フィードバック UI を実装
- 正解時は緑背景で「正解！」、不正解時は赤背景で「不正解」を表示
- 不正解時に正解の読み仮名を「正解：〇〇」の形式で明示
- フィードバック表示中は選択肢ボタンを無効化し、「次へ」ボタンを表示
- `SessionScreen` に `feedback` state・`handleNext` 関数を追加し、2フェーズフローに変更

## 設計メモ

**2フェーズフローの採用**：「選択肢タップ → 即次問題」から「選択肢タップ → フィードバック → 次へ → 次問題」に変更。
フィードバック state は SessionScreen が保持し（`isCorrect()` を知っているのが SessionScreen のため）、
ProblemScreen は props 経由で受け取るプレゼンテーション層として設計。

**`Feedback` 型の export**：`SessionScreen` で再利用するため `ProblemScreen.tsx` から export。
型定義のみのファイルには切り出さず、コロケーションを優先。

## 対応 Issue

Closes #6

## 影響範囲

- `ProblemScreen.tsx`：`Feedback` 型を新規 export、`feedback`/`onNext` props 追加
- `SessionScreen.tsx`：`feedback` state・`handleNext` 追加、`handleAnswer` を2フェーズに変更
- 呼び出し元は `SessionScreen` のみ。`RootNavigator` への影響なし

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過（49件 GREEN、カバレッジ 100%）