### PR TITLE
feat: セッション結果画面を実装する（#7）

### DIFF
--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,12 +1,26 @@
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, FlatList } from 'react-native'
 import type { ResultScreenProps } from '../navigation/types'
+import { getAllProblems } from '../infrastructure/problemRepository'
 
-export default function ResultScreen({ route }: ResultScreenProps) {
+export default function ResultScreen({ route, navigation }: ResultScreenProps) {
   const { correctCount, missedProblemIds } = route.params
+  const allProblems = getAllProblems()
+  const missedProblems = allProblems.filter((p) => missedProblemIds.includes(p.id))
+
   return (
     <View style={styles.container}>
-      <Text testID="correct-count">正解数: {correctCount}</Text>
-      <Text testID="missed-count">間違えた問題数: {missedProblemIds.length}</Text>
+      <Text testID="correct-count">{correctCount} / 10</Text>
+      <FlatList
+        data={missedProblems}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <Text>{item.question}</Text>}
+      />
+      <TouchableOpacity onPress={() => navigation.navigate('Session')}>
+        <Text>もう一度</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.navigate('Home')}>
+        <Text>終了</Text>
+      </TouchableOpacity>
     </View>
   )
 }

--- a/tests/screens/ResultScreen.test.tsx
+++ b/tests/screens/ResultScreen.test.tsx
@@ -1,33 +1,77 @@
-import { render, screen } from '@testing-library/react-native'
+import { render, screen, fireEvent } from '@testing-library/react-native'
 import ResultScreen from '../../src/screens/ResultScreen'
-
-const mockNavigation = {} as any
 
 describe('ResultScreen', () => {
   describe('表示', () => {
-    it('正解数が表示される', () => {
+    it('{correctCount} / 10 の形式で正解数が表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
-        params: { correctCount: 7, missedProblemIds: ['p-001', 'p-003', 'p-005'] },
+        params: { correctCount: 7, missedProblemIds: ['p001', 'p003'] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
-      expect(screen.getByText('正解数: 7')).toBeDefined()
+      expect(screen.getByText('7 / 10')).toBeDefined()
     })
 
-    it('間違えた問題数が表示される', () => {
+    it('間違えた問題が一覧で表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
+      // p001: "漢字", p002: "読書"（data/problems/sample.json の実 ID を使用）
       const mockRoute = {
-        params: { correctCount: 7, missedProblemIds: ['p-001', 'p-003', 'p-005'] },
+        params: { correctCount: 8, missedProblemIds: ['p001', 'p002'] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
-      expect(screen.getByText('間違えた問題数: 3')).toBeDefined()
+      expect(screen.getByText('漢字')).toBeDefined()
+      expect(screen.getByText('読書')).toBeDefined()
     })
 
     it('正解数 0 のときも正しく表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
         params: { correctCount: 0, missedProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
-      expect(screen.getByText('正解数: 0')).toBeDefined()
-      expect(screen.getByText('間違えた問題数: 0')).toBeDefined()
+      expect(screen.getByText('0 / 10')).toBeDefined()
+    })
+
+    it('「もう一度」ボタンが表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockRoute = {
+        params: { correctCount: 5, missedProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('もう一度')).toBeDefined()
+    })
+
+    it('「終了」ボタンが表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockRoute = {
+        params: { correctCount: 5, missedProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByText('終了')).toBeDefined()
+    })
+  })
+
+  describe('操作', () => {
+    it('「もう一度」をタップすると Session に遷移する', () => {
+      const mockNavigate = jest.fn()
+      const mockNavigation = { navigate: mockNavigate } as any
+      const mockRoute = {
+        params: { correctCount: 5, missedProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('もう一度'))
+      expect(mockNavigate).toHaveBeenCalledWith('Session')
+    })
+
+    it('「終了」をタップすると Home に遷移する', () => {
+      const mockNavigate = jest.fn()
+      const mockNavigation = { navigate: mockNavigate } as any
+      const mockRoute = {
+        params: { correctCount: 5, missedProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      fireEvent.press(screen.getByText('終了'))
+      expect(mockNavigate).toHaveBeenCalledWith('Home')
     })
   })
 })


### PR DESCRIPTION
## 変更内容

- 正解数の表示形式を `{correctCount} / 10` に変更
- 間違えた問題の一覧（漢字表示）を FlatList で追加
- 「もう一度」ボタン（Session 画面へ遷移）を追加
- 「終了」ボタン（Home 画面へ遷移）を追加
- ResultScreen のテストを全面刷新（7ケース、TDD Red→Green で実施）

## 設計メモ

- 間違えた問題の解決に `getAllProblems()` + `filter` を使用。問題数が最大10件と少ないため O(n×m) で許容範囲。
- `navigate('Session')` によるスタックの積み上げ動作はフェーズ3以降のナビゲーション整理で対応予定（Issue スコープ外）。

## 対応 Issue

Closes #7

## 影響範囲

- 変更は `ResultScreen.tsx` と対応テストの 2 ファイルのみ
- 呼び出し元 `RootNavigator.tsx` はコンポーネント登録のみで props 変更の影響なし
- domain 層・infrastructure 層の変更なし

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過（53件、coverage 100%）