### PR TITLE
feat: 2回連続正解で苦手フラグ解除フィードバックを実装する（#10）

### DIFF
--- a/docs/adr/0003-review-rule.md
+++ b/docs/adr/0003-review-rule.md
@@ -12,6 +12,7 @@ Accepted
 
 1. **初回ミス** → 当日セッション内で再出題する
 2. **2回連続正解** → 苦手フラグを解除する
+3. **苦手フラグ解除通知** → `isJustMastered(before, after)` で判定し、ResultScreen で「苦手克服！」セクションを表示する
 
 実装：`src/domain/review.ts`
 テスト：`tests/domain/review.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@react-navigation/native": "^7.2.0",
         "@react-navigation/native-stack": "^7.14.7",
-        "expo": "^54.0.0",
+        "expo": "~54.0.0",
         "expo-asset": "~12.0.12",
         "expo-constants": "~18.0.13",
         "expo-file-system": "~19.0.21",

--- a/src/domain/review.ts
+++ b/src/domain/review.ts
@@ -15,6 +15,11 @@ export function shouldReview(record: ReviewRecord): boolean {
   return record.missCount >= 1 && record.consecutiveCorrect < 2
 }
 
+// 更新前後のレコードを比較して、今回のセッションで苦手フラグが解除されたか判定する
+export function isJustMastered(before: ReviewRecord, after: ReviewRecord): boolean {
+  return before.missCount >= 1 && before.consecutiveCorrect < 2 && after.consecutiveCorrect >= 2
+}
+
 // 回答後にレコードを更新する
 export function updateRecord(record: ReviewRecord, correct: boolean): ReviewRecord {
   if (correct) {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -6,6 +6,7 @@ export type RootStackParamList = {
   Result: {
     correctCount: number
     missedProblemIds: string[]
+    masteredProblemIds: string[]
   }
 }
 

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -3,13 +3,24 @@ import type { ResultScreenProps } from '../navigation/types'
 import { getAllProblems } from '../infrastructure/problemRepository'
 
 export default function ResultScreen({ route, navigation }: ResultScreenProps) {
-  const { correctCount, missedProblemIds } = route.params
+  const { correctCount, missedProblemIds, masteredProblemIds } = route.params
   const allProblems = getAllProblems()
   const missedProblems = allProblems.filter((p) => missedProblemIds.includes(p.id))
+  const masteredProblems = allProblems.filter((p) => masteredProblemIds.includes(p.id))
 
   return (
     <View style={styles.container}>
       <Text testID="correct-count">{correctCount} / 10</Text>
+      {masteredProblems.length > 0 && (
+        <View testID="mastered-section">
+          <Text>苦手克服！</Text>
+          <FlatList
+            data={masteredProblems}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <Text>{item.question}</Text>}
+          />
+        </View>
+      )}
       <FlatList
         data={missedProblems}
         keyExtractor={(item) => item.id}

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -37,10 +37,11 @@ export default function SessionScreen({ navigation }: SessionScreenProps) {
 
   async function handleNext() {
     if (currentIndex + 1 >= problems.length) {
-      await saveSessionResult(initialProblems, missedProblemIds)
+      const masteredProblemIds = await saveSessionResult(initialProblems, missedProblemIds)
       navigation.navigate('Result', {
         correctCount,
         missedProblemIds,
+        masteredProblemIds,
       })
     } else {
       setCurrentIndex(currentIndex + 1)

--- a/src/usecase/saveSessionResult.ts
+++ b/src/usecase/saveSessionResult.ts
@@ -1,18 +1,22 @@
 import type { Problem } from '../domain/problem'
-import { createInitialRecord, updateRecord } from '../domain/review'
+import { createInitialRecord, updateRecord, isJustMastered } from '../domain/review'
 import { getRecord, saveRecords } from '../infrastructure/reviewRecordRepository'
 
 export async function saveSessionResult(
   problems: Problem[],
   missedProblemIds: string[]
-): Promise<void> {
+): Promise<string[]> {
   const missedSet = new Set(missedProblemIds)
-  const updated = await Promise.all(
+  const pairs = await Promise.all(
     problems.map(async (problem) => {
       const existing = await getRecord(problem.id)
       const base = existing ?? createInitialRecord(problem.id)
-      return updateRecord(base, !missedSet.has(problem.id))
+      const updated = updateRecord(base, !missedSet.has(problem.id))
+      return { base, updated }
     })
   )
-  await saveRecords(updated)
+  await saveRecords(pairs.map(({ updated }) => updated))
+  return pairs
+    .filter(({ base, updated }) => isJustMastered(base, updated))
+    .map(({ updated }) => updated.problemId)
 }

--- a/tests/domain/review.test.ts
+++ b/tests/domain/review.test.ts
@@ -1,4 +1,4 @@
-import { shouldReview, updateRecord, createInitialRecord } from '../../src/domain/review'
+import { shouldReview, updateRecord, createInitialRecord, isJustMastered } from '../../src/domain/review'
 import type { ReviewRecord } from '../../src/domain/review'
 
 const baseRecord: ReviewRecord = {
@@ -52,5 +52,37 @@ describe('updateRecord', () => {
     const updated = updateRecord(record, false)
     expect(updated.missCount).toBe(2)
     expect(updated.consecutiveCorrect).toBe(0)
+  })
+})
+
+describe('isJustMastered', () => {
+  it('苦手あり・consecutiveCorrect が 1→2 になったとき true を返す', () => {
+    const before = { ...baseRecord, missCount: 1, consecutiveCorrect: 1 }
+    const after  = { ...baseRecord, missCount: 1, consecutiveCorrect: 2 }
+    expect(isJustMastered(before, after)).toBe(true)
+  })
+
+  it('before がすでに consecutiveCorrect >= 2 のとき false を返す（解除済み）', () => {
+    const before = { ...baseRecord, missCount: 1, consecutiveCorrect: 2 }
+    const after  = { ...baseRecord, missCount: 1, consecutiveCorrect: 3 }
+    expect(isJustMastered(before, after)).toBe(false)
+  })
+
+  it('after.consecutiveCorrect が 2 未満のとき false を返す', () => {
+    const before = { ...baseRecord, missCount: 1, consecutiveCorrect: 0 }
+    const after  = { ...baseRecord, missCount: 1, consecutiveCorrect: 1 }
+    expect(isJustMastered(before, after)).toBe(false)
+  })
+
+  it('missCount が 0（苦手なし）のとき false を返す', () => {
+    const before = { ...baseRecord, missCount: 0, consecutiveCorrect: 1 }
+    const after  = { ...baseRecord, missCount: 0, consecutiveCorrect: 2 }
+    expect(isJustMastered(before, after)).toBe(false)
+  })
+
+  it('1回正解 → 1回不正解ではフラグが解除されない', () => {
+    const afterCorrect = updateRecord({ ...baseRecord, missCount: 1, consecutiveCorrect: 0 }, true)
+    const afterMiss    = updateRecord(afterCorrect, false)
+    expect(isJustMastered(afterCorrect, afterMiss)).toBe(false)
   })
 })

--- a/tests/screens/ResultScreen.test.tsx
+++ b/tests/screens/ResultScreen.test.tsx
@@ -6,7 +6,7 @@ describe('ResultScreen', () => {
     it('{correctCount} / 10 の形式で正解数が表示される', () => {
       const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
-        params: { correctCount: 7, missedProblemIds: ['p001', 'p003'] },
+        params: { correctCount: 7, missedProblemIds: ['p001', 'p003'], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       expect(screen.getByText('7 / 10')).toBeDefined()
@@ -16,7 +16,7 @@ describe('ResultScreen', () => {
       const mockNavigation = { navigate: jest.fn() } as any
       // p001: "漢字", p002: "読書"（data/problems/sample.json の実 ID を使用）
       const mockRoute = {
-        params: { correctCount: 8, missedProblemIds: ['p001', 'p002'] },
+        params: { correctCount: 8, missedProblemIds: ['p001', 'p002'], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       expect(screen.getByText('漢字')).toBeDefined()
@@ -26,7 +26,7 @@ describe('ResultScreen', () => {
     it('正解数 0 のときも正しく表示される', () => {
       const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
-        params: { correctCount: 0, missedProblemIds: [] },
+        params: { correctCount: 0, missedProblemIds: [], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       expect(screen.getByText('0 / 10')).toBeDefined()
@@ -35,7 +35,7 @@ describe('ResultScreen', () => {
     it('「もう一度」ボタンが表示される', () => {
       const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
-        params: { correctCount: 5, missedProblemIds: [] },
+        params: { correctCount: 5, missedProblemIds: [], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       expect(screen.getByText('もう一度')).toBeDefined()
@@ -44,7 +44,7 @@ describe('ResultScreen', () => {
     it('「終了」ボタンが表示される', () => {
       const mockNavigation = { navigate: jest.fn() } as any
       const mockRoute = {
-        params: { correctCount: 5, missedProblemIds: [] },
+        params: { correctCount: 5, missedProblemIds: [], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       expect(screen.getByText('終了')).toBeDefined()
@@ -56,7 +56,7 @@ describe('ResultScreen', () => {
       const mockNavigate = jest.fn()
       const mockNavigation = { navigate: mockNavigate } as any
       const mockRoute = {
-        params: { correctCount: 5, missedProblemIds: [] },
+        params: { correctCount: 5, missedProblemIds: [], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       fireEvent.press(screen.getByText('もう一度'))
@@ -67,11 +67,42 @@ describe('ResultScreen', () => {
       const mockNavigate = jest.fn()
       const mockNavigation = { navigate: mockNavigate } as any
       const mockRoute = {
-        params: { correctCount: 5, missedProblemIds: [] },
+        params: { correctCount: 5, missedProblemIds: [], masteredProblemIds: [] },
       } as any
       render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
       fireEvent.press(screen.getByText('終了'))
       expect(mockNavigate).toHaveBeenCalledWith('Home')
+    })
+  })
+
+  describe('習得フィードバック', () => {
+    it('masteredProblemIds が空のときは習得セクションが表示されない', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockRoute = {
+        params: { correctCount: 5, missedProblemIds: [], masteredProblemIds: [] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.queryByTestId('mastered-section')).toBeNull()
+    })
+
+    it('masteredProblemIds に ID があるとき習得セクションが表示される', () => {
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockRoute = {
+        params: { correctCount: 8, missedProblemIds: [], masteredProblemIds: ['p001'] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByTestId('mastered-section')).toBeDefined()
+    })
+
+    it('習得した問題の漢字が習得セクションに表示される', () => {
+      // p001.question = '漢字'（data/problems/sample.json 準拠）
+      const mockNavigation = { navigate: jest.fn() } as any
+      const mockRoute = {
+        params: { correctCount: 8, missedProblemIds: [], masteredProblemIds: ['p001'] },
+      } as any
+      render(<ResultScreen navigation={mockNavigation} route={mockRoute} />)
+      expect(screen.getByTestId('mastered-section')).toBeDefined()
+      expect(screen.getByText('漢字')).toBeDefined()
     })
   })
 })

--- a/tests/screens/SessionScreen.test.tsx
+++ b/tests/screens/SessionScreen.test.tsx
@@ -34,7 +34,7 @@ beforeEach(() => {
   jest.clearAllMocks()
   mockGetAllProblems.mockReturnValue(tenProblems)
   mockPickSession.mockReturnValue(tenProblems)
-  mockSaveSessionResult.mockResolvedValue(undefined)
+  mockSaveSessionResult.mockResolvedValue([])
 })
 
 describe('SessionScreen', () => {
@@ -70,6 +70,7 @@ describe('SessionScreen', () => {
         expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
           correctCount: expect.any(Number),
           missedProblemIds: expect.any(Array),
+          masteredProblemIds: expect.any(Array),
         }))
       })
     })
@@ -91,6 +92,7 @@ describe('SessionScreen', () => {
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
           correctCount: 9,
+          masteredProblemIds: expect.any(Array),
         }))
       })
     })
@@ -112,6 +114,7 @@ describe('SessionScreen', () => {
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
           missedProblemIds: ['p002'],
+          masteredProblemIds: expect.any(Array),
         }))
       })
     })
@@ -153,6 +156,20 @@ describe('SessionScreen', () => {
       fireEvent.press(screen.getByText('よみ1'))
       fireEvent.press(screen.getByText('次へ'))
       expect(mockSaveSessionResult).not.toHaveBeenCalled()
+    })
+
+    it('saveSessionResult が返した masteredProblemIds が Result に渡される', async () => {
+      mockSaveSessionResult.mockResolvedValue(['p001', 'p003'])
+      render(<SessionScreen navigation={mockNavigation} route={mockRoute} />)
+      for (let i = 1; i <= 10; i++) {
+        fireEvent.press(screen.getByText(`よみ${i}`))
+        fireEvent.press(screen.getByText('次へ'))
+      }
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
+          masteredProblemIds: ['p001', 'p003'],
+        }))
+      })
     })
   })
 
@@ -202,6 +219,7 @@ describe('SessionScreen', () => {
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('Result', expect.objectContaining({
           correctCount: expect.any(Number),
+          masteredProblemIds: expect.any(Array),
         }))
       })
     })

--- a/tests/usecase/saveSessionResult.test.ts
+++ b/tests/usecase/saveSessionResult.test.ts
@@ -80,4 +80,48 @@ describe('saveSessionResult', () => {
     expect(ids).toContain('p003')
     expect(savedRecords).toHaveLength(3)
   })
+
+  describe('masteredProblemIds の返却', () => {
+    it('consecutiveCorrect 1→2 になった苦手問題の ID を返す', async () => {
+      const existing: ReviewRecord = {
+        problemId: 'p001', missCount: 1, consecutiveCorrect: 1,
+        lastAttemptedAt: '2026-03-27T00:00:00.000Z',
+      }
+      mockGetRecord.mockImplementation((id: string) =>
+        id === 'p001' ? Promise.resolve(existing) : Promise.resolve(null)
+      )
+      const result = await saveSessionResult(problems, []) // p001 正解
+      expect(result).toContain('p001')
+    })
+
+    it('consecutiveCorrect が 2 に届かない問題は含まれない', async () => {
+      const existing: ReviewRecord = {
+        problemId: 'p001', missCount: 1, consecutiveCorrect: 0,
+        lastAttemptedAt: '2026-03-27T00:00:00.000Z',
+      }
+      mockGetRecord.mockImplementation((id: string) =>
+        id === 'p001' ? Promise.resolve(existing) : Promise.resolve(null)
+      )
+      const result = await saveSessionResult(problems, [])
+      expect(result).not.toContain('p001')
+    })
+
+    it('苦手フラグがない問題（missCount=0）は含まれない', async () => {
+      const existing: ReviewRecord = {
+        problemId: 'p001', missCount: 0, consecutiveCorrect: 1,
+        lastAttemptedAt: '2026-03-27T00:00:00.000Z',
+      }
+      mockGetRecord.mockImplementation((id: string) =>
+        id === 'p001' ? Promise.resolve(existing) : Promise.resolve(null)
+      )
+      const result = await saveSessionResult(problems, [])
+      expect(result).not.toContain('p001')
+    })
+
+    it('解除がない場合は空配列を返す', async () => {
+      mockGetRecord.mockResolvedValue(null)
+      const result = await saveSessionResult(problems, ['p001', 'p002', 'p003'])
+      expect(result).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
## 変更内容

- `isJustMastered(before, after)` を `domain/review.ts` に追加し、苦手フラグが解除された瞬間を判定する
- `saveSessionResult` の戻り値を `Promise<void>` → `Promise<string[]>` に変更し、解除された問題 ID を返却する
- `SessionScreen` が `masteredProblemIds` を `ResultScreen` に渡す
- `ResultScreen` に「苦手克服！」セクションを追加し、今回のセッションで習得した問題の漢字を一覧表示する

## 設計メモ

- `isJustMastered` の判定を domain 層に置くことで、ビジネスルール（「何をもって苦手解除とするか」）をテスト可能な純粋関数として表現している
- `saveSessionResult` がセッション終了時に一括実行されるアーキテクチャ上、フィードバック表示は ResultScreen が適切（セッション中のリアルタイム通知は設計を複雑にするため採用しなかった）

## 対応 Issue

Closes #10

## 影響範囲

- `src/domain/review.ts`: `isJustMastered` 追加（呼び出し元: `saveSessionResult.ts` のみ）
- `src/usecase/saveSessionResult.ts`: 戻り値 void → string[]（呼び出し元: `SessionScreen.tsx` のみ）
- `src/navigation/types.ts`: Result params に `masteredProblemIds` 追加
- `src/screens/SessionScreen.tsx` / `ResultScreen.tsx`: UI フロー更新
- 全変更ファイルのテスト更新済み

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過（88 tests, coverage 100%）