### PR TITLE
fix: Android で漢字が中国語グリフで表示される問題を修正する（#73）

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,19 @@
 import { NavigationContainer } from '@react-navigation/native'
+import { NotoSansJP_400Regular, NotoSansJP_700Bold } from '@expo-google-fonts/noto-sans-jp'
+import { useFonts } from 'expo-font'
 import RootNavigator from './src/navigation/RootNavigator'
+import { FONTS } from './src/constants/fonts'
 
 export default function App() {
+  const [loaded] = useFonts({
+    [FONTS.regular]: NotoSansJP_400Regular,
+    [FONTS.bold]: NotoSansJP_700Bold,
+  })
+
+  if (!loaded) {
+    return null
+  }
+
   return (
     <NavigationContainer>
       <RootNavigator />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kanji-learning",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/noto-sans-jp": "^0.4.3",
         "@react-navigation/native": "^7.2.0",
         "@react-navigation/native-stack": "^7.14.7",
         "expo": "~54.0.0",
@@ -1736,6 +1737,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/noto-sans-jp": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/noto-sans-jp/-/noto-sans-jp-0.4.3.tgz",
+      "integrity": "sha512-Fl+Z6vtD24HFAYsvzB0S9Nery1ly16B9PesdY0wBd+wEHAvkNglnkTUspU0HqGOubkmoa8zusJrKv6vDx1o70A==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:e2e": "detox build -c android.emu.debug"
   },
   "dependencies": {
+    "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@react-navigation/native": "^7.2.0",
     "@react-navigation/native-stack": "^7.14.7",
     "expo": "~54.0.0",

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -1,0 +1,4 @@
+export const FONTS = {
+  regular: 'NotoSansJP_400Regular',
+  bold: 'NotoSansJP_700Bold',
+} as const

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import type { HomeScreenProps } from '../navigation/types'
+import { FONTS } from '../constants/fonts'
 
 export default function HomeScreen({ navigation }: HomeScreenProps) {
   return (
@@ -18,7 +19,7 @@ export default function HomeScreen({ navigation }: HomeScreenProps) {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 32 },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 32, fontFamily: FONTS.bold },
   button: { backgroundColor: '#4A90E2', borderRadius: 8, padding: 16 },
-  buttonText: { color: '#fff', fontSize: 18 },
+  buttonText: { color: '#fff', fontSize: 18, fontFamily: FONTS.regular },
 })

--- a/src/screens/ProblemScreen.tsx
+++ b/src/screens/ProblemScreen.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import type { Problem } from '../domain/problem'
+import { FONTS } from '../constants/fonts'
 
 export type Feedback = {
   isCorrect: boolean
@@ -69,6 +70,7 @@ const styles = StyleSheet.create({
     fontSize: 64,
     fontWeight: 'bold',
     marginBottom: 48,
+    fontFamily: FONTS.bold,
   },
   choices: {
     width: '100%',
@@ -82,6 +84,7 @@ const styles = StyleSheet.create({
   },
   choiceText: {
     fontSize: 20,
+    fontFamily: FONTS.regular,
   },
   feedbackContainer: {
     width: '100%',
@@ -99,6 +102,7 @@ const styles = StyleSheet.create({
   feedbackText: {
     fontSize: 20,
     fontWeight: 'bold',
+    fontFamily: FONTS.bold,
   },
   feedbackTextCorrect: {
     color: '#155724',
@@ -110,6 +114,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#721c24',
     marginTop: 8,
+    fontFamily: FONTS.regular,
   },
   nextButton: {
     backgroundColor: '#007AFF',
@@ -123,5 +128,6 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 18,
     fontWeight: 'bold',
+    fontFamily: FONTS.bold,
   },
 })

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,6 +1,7 @@
 import { View, Text, StyleSheet, TouchableOpacity, FlatList } from 'react-native'
 import type { ResultScreenProps } from '../navigation/types'
 import { getAllProblems } from '../infrastructure/problemRepository'
+import { FONTS } from '../constants/fonts'
 
 export default function ResultScreen({ route, navigation }: ResultScreenProps) {
   const { correctCount, missedProblemIds, masteredProblemIds } = route.params
@@ -10,27 +11,27 @@ export default function ResultScreen({ route, navigation }: ResultScreenProps) {
 
   return (
     <View style={styles.container}>
-      <Text testID="correct-count">{correctCount} / 10</Text>
+      <Text testID="correct-count" style={styles.text}>{correctCount} / 10</Text>
       {masteredProblems.length > 0 && (
         <View testID="mastered-section">
-          <Text>苦手克服！</Text>
+          <Text style={styles.text}>苦手克服！</Text>
           <FlatList
             data={masteredProblems}
             keyExtractor={(item) => item.id}
-            renderItem={({ item }) => <Text>{item.question}</Text>}
+            renderItem={({ item }) => <Text style={styles.text}>{item.question}</Text>}
           />
         </View>
       )}
       <FlatList
         data={missedProblems}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <Text>{item.question}</Text>}
+        renderItem={({ item }) => <Text style={styles.text}>{item.question}</Text>}
       />
       <TouchableOpacity onPress={() => navigation.navigate('Session')}>
-        <Text>もう一度</Text>
+        <Text style={styles.text}>もう一度</Text>
       </TouchableOpacity>
       <TouchableOpacity onPress={() => navigation.navigate('Home')}>
-        <Text>終了</Text>
+        <Text style={styles.text}>終了</Text>
       </TouchableOpacity>
     </View>
   )
@@ -38,4 +39,5 @@ export default function ResultScreen({ route, navigation }: ResultScreenProps) {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontFamily: FONTS.regular },
 })

--- a/src/screens/SessionScreen.tsx
+++ b/src/screens/SessionScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
+import { FONTS } from '../constants/fonts'
 import { isCorrect } from '../domain/answer'
 import type { Problem } from '../domain/problem'
 import { getAllProblems } from '../infrastructure/problemRepository'
@@ -55,7 +56,7 @@ export default function SessionScreen({ navigation }: SessionScreenProps) {
         {currentIndex + 1} / {problems.length}
       </Text>
       {reviewProblemIds.has(currentProblem.id) && (
-        <Text testID="review-badge">復習</Text>
+        <Text testID="review-badge" style={{ fontFamily: FONTS.regular }}>復習</Text>
       )}
       <ProblemScreen
         problem={currentProblem}
@@ -69,5 +70,5 @@ export default function SessionScreen({ navigation }: SessionScreenProps) {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  progress: { textAlign: 'center', padding: 16, fontSize: 16 },
+  progress: { textAlign: 'center', padding: 16, fontSize: 16, fontFamily: FONTS.regular },
 })

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,5 +1,16 @@
 import { render, screen } from '@testing-library/react-native'
+import * as ExpoFont from 'expo-font'
 import App from '../App'
+
+jest.mock('expo-font', () => ({
+  useFonts: jest.fn(() => [true, null]),
+  loadAsync: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@expo-google-fonts/noto-sans-jp', () => ({
+  NotoSansJP_400Regular: 0,
+  NotoSansJP_700Bold: 0,
+}))
 
 describe('App', () => {
   it('ホーム画面のタイトルが表示される', () => {
@@ -10,5 +21,11 @@ describe('App', () => {
   it('セッション開始ボタンが表示される', () => {
     render(<App />)
     expect(screen.getByTestId('start-session-button')).toBeDefined()
+  })
+
+  it('フォント読み込み中は何も表示されない', () => {
+    jest.mocked(ExpoFont.useFonts).mockReturnValueOnce([false, null])
+    const { toJSON } = render(<App />)
+    expect(toJSON()).toBeNull()
   })
 })


### PR DESCRIPTION
## 変更内容

- `@expo-google-fonts/noto-sans-jp` を追加（Regular / Bold）
- `src/constants/fonts.ts` を新規作成してフォント名定数（`NotoSansJP_400Regular` / `NotoSansJP_700Bold`）を管理
- `App.tsx` に `useFonts` を追加してフォントをロード。未完了時は `null` を返す
- 全4スクリーン（Home / Problem / Session / Result）の全テキストに `fontFamily` を明示指定
- `tests/App.test.tsx` に `expo-font` モックとフォントロード中 null テストを追加

## 設計メモ

- TTF ファイルを `assets/` に配置する代わりに `@expo-google-fonts/noto-sans-jp` パッケージを利用。フォントのバージョン管理が npm に乗り、将来のアップデートが容易になる。
- `fontWeight: 'bold'` を指定しているスタイルには `FONTS.bold`（700Bold）、それ以外は `FONTS.regular`（400Regular）を対応させた。Android では `fontWeight` だけでは太字が効かないケースがあるため、明示的なフォントファイルで補完する。
- フォントロード前に `null` を返すことで、フォント未ロード状態でテキストが一瞬システムフォントで描画される Unstyled Flash を防ぐ。

## 対応 Issue

Closes #73

## 影響範囲

- `App.tsx`：useFonts 追加、フォントロード前に null を返す新分岐
- `src/constants/fonts.ts`：新規（全4スクリーンから参照）
- 全4スクリーン：StyleSheet に `fontFamily` プロパティを追加（ロジック変更なし）
- `tests/App.test.tsx`：expo-font モック・null 分岐テスト追加

## 確認項目
- [x] lint 通過
- [x] typecheck 通過
- [x] test 通過